### PR TITLE
fix: avoid state changes in LabelLink

### DIFF
--- a/packages/client/src/app/containers/navigation.js
+++ b/packages/client/src/app/containers/navigation.js
@@ -5,6 +5,7 @@ import { push } from "react-router-redux";
 import { bindActionCreators } from "redux";
 import { MainNavigation } from "@patternplate/components";
 import { Link } from "@patternplate/components";
+import { patchLocation } from "../actions";
 
 import selectNavigation from "../selectors/navigation";
 import selectDocs from "../selectors/docs";
@@ -34,6 +35,9 @@ function mapDispatch(dispatch) {
 
         const parsed = url.parse(e.currentTarget.href);
         return push(`${parsed.pathname}?${parsed.query}`);
+      },
+      onLabelClick(query) {
+        return patchLocation({query});
       }
     },
     dispatch

--- a/packages/components/src/main-navigation/index.js
+++ b/packages/components/src/main-navigation/index.js
@@ -69,7 +69,8 @@ class Navigation extends React.Component {
               <React.Fragment>
                 <NavigationLabel
                   enabled={props.patternsEnabled}
-                  name="patterns">
+                  name="patterns"
+                  onClick={props.onLabelClick}>
                   Patterns
                 </NavigationLabel>
                 {
@@ -105,8 +106,8 @@ Navigation.defaultProps = {
 function NavigationLabel(props) {
   return (
       <StyledLabelLink
-        query={{[`${props.name}-enabled`]: !props.enabled}}
         title={`${props.enabled ? 'Close' : 'Expand'} ${props.children} list`}
+        onClick={()=> props.onClick({[`${props.name}-enabled`]: !props.enabled})}
         >
         <StyledLabel>
           <StyledLabelIcon enabled={props.enabled}>▼</StyledLabelIcon>
@@ -143,9 +144,6 @@ const StyledNavigation = styled.div`
 `;
 
 const StyledLabel = styled.div`
-  position: sticky;
-  top: 60px;
-  left: 0;
   padding: 5px 10px;
   display: flex;
   align-items: center;
@@ -157,8 +155,12 @@ const StyledLabel = styled.div`
   border-width: 1px 0;
 `;
 
-const StyledLabelLink = styled(Link)`
+const StyledLabelLink = styled.div`
+  position: sticky;
+  top: 60px;
+  left: 0;
   color: ${props => props.theme.color};
+  cursor: pointer;
   text-decoration: none;
 `;
 


### PR DESCRIPTION
As discussed with Mario. 

Fixes a bug observed in Chrome where the `LabelLink` jumped erratically when its href changed.

![pp_bug_label](https://user-images.githubusercontent.com/19954864/37086649-5ccac4ec-21f8-11e8-848c-e3c35e568b75.gif)
