### PR TITLE
fix: contributing guide was incorrect and spelling errors in docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,8 +6,16 @@ We love pull requests. And following this guidelines will make your pull request
 
 * If it’s your first pull request, watch [this amazing course](http://makeapullrequest.com/) by [Kent C. Dodds](https://twitter.com/kentcdodds).
 * Install [EditorConfig](http://editorconfig.org/) plugin for your code editor to make sure it uses correct settings.
-* Fork the repository and clone your fork.
-* Install dependencies: `npm install`.
+
+```sh
+git clone https://github.com/patternplate/patternplate.git
+cd patternplate
+yarn
+yarn start
+
+# start the local component library
+yarn patternplate start
+```
 
 ## Development workflow
 

--- a/docs/advanced/build.md
+++ b/docs/advanced/build.md
@@ -278,7 +278,7 @@ the ubiquitous in the JavaScript ecosystem at the time of writing.
 
 * `patternplate` works with all build systems that can emit JavaScript. 
 
-* Configure you build to produce artifacts in `lib` to pick them up with patternplate by default
+* Configure your build to produce artifacts in `lib` and to pick them up with patternplate by default
 
 * The `patternplate` development watcher works with the results of e.g. the Babel watch mode.
 

--- a/docs/advanced/deploy.md
+++ b/docs/advanced/deploy.md
@@ -132,7 +132,7 @@ scroll down to the **GitHub Pages** section.
 5. Click on the dropdown under **Source** and select `master branch docs folder`. Make sure
 to hit the save button next to the dropdown.
 
-6. Navigate your browser to `https://[username].github.com/my-patternplate/`. You should the very same interface you create locally earlier. 
+6. Navigate your browser to `https://[username].github.com/my-patternplate/`. You should see the very same interface you created locally earlier. 
 
 ![](https://patternplate.github.io/media/images/screenshot-hello-world.svg)
 

--- a/docs/advanced/deploy.md
+++ b/docs/advanced/deploy.md
@@ -132,7 +132,7 @@ scroll down to the **GitHub Pages** section.
 5. Click on the dropdown under **Source** and select `master branch docs folder`. Make sure
 to hit the save button next to the dropdown.
 
-6. Navigate your browser to `https://[username].github.com/my-patternplate`. You should the very same interface you create locally earlier. 
+6. Navigate your browser to `https://[username].github.com/my-patternplate/`. You should the very same interface you create locally earlier. 
 
 ![](https://patternplate.github.io/media/images/screenshot-hello-world.svg)
 

--- a/docs/guides/use-widgets.md
+++ b/docs/guides/use-widgets.md
@@ -140,7 +140,7 @@ you do that!
 1. Create a second widget block in `./README.md` by adding this code at the end of the file:
 
   ````md
-    ## My second widget
+  ## My second widget
   ```widget
   const React = require("react");
   const {ComponentDemo} = require("@patternplate/widgets");

--- a/docs/guides/virtual-folders.md
+++ b/docs/guides/virtual-folders.md
@@ -178,9 +178,9 @@ So we'll add a new file there:
 ## Take aways
 
 * Meta data can be added to documentation in `frontmatter` blocks 
-* Tags, flags, etc. mcan be used to search trough both components and docs
+* Tags, flags, etc. can be used to search through both components and docs
 * There is fuzzy and structured search in patternplate
-* Structured search queries can be used to crate **Virtual Folders**
+* Structured search queries can be used to create **Virtual Folders**
 
 ## Up next
 


### PR DESCRIPTION
The [contributing guidelines](https://github.com/patternplate/patternplate/blob/master/.github/CONTRIBUTING.md) had incorrect instructions, so I brought them in sync with the main project README

Also fixed some typos and spelling errors in the guides.

Love this project!