### PR TITLE
feat: pass a context object to demo renderer

### DIFF
--- a/docs/reference/renderers.md
+++ b/docs/reference/renderers.md
@@ -75,6 +75,14 @@ type Input {
   element?: Node
 }
 
+type Context {
+  /**
+   * The project relative base path
+   * to the processed pattern
+   */
+  dirname: string;
+}
+
 type Output {
   /**
    * HTML fragment to inject into <head>
@@ -102,7 +110,7 @@ type Output {
   js?: string;
 }
 
-function render(Input): Output;
+function render(Input, Context): Output;
 ```
 
 ### mount

--- a/packages/api/src/demo.js
+++ b/packages/api/src/demo.js
@@ -39,8 +39,9 @@ async function demo(options) {
       const getModule = fromFs(fs);
       const bundle = getModule(BUNDLE_PATH);
       const component = getComponent(bundle, found);
+      const context = getContext(found);
       const render = component.render || getModule(RENDER_PATH);
-      const content = render(component);
+      const content = render(component, context);
       res.send(html(content, found));
     } catch (err) {
       const error = Array.isArray(err) ? new AggregateError(err) : err;
@@ -86,6 +87,12 @@ function getComponent(components, data) {
   }
 
   return top;
+}
+
+function getContext(pattern) {
+  return {
+    dirname: path.dirname(pattern.path)
+  };
 }
 
 function fromFs(fs) {


### PR DESCRIPTION
This provides a context object for the _api/demo_ renderer including a `dirname` property. This would make it possible to process LessCSS or SASS by writing an own `render.js` and using the `context.dirname` property to configure the given style parser.