### PR TITLE
chore: fix demo theme ui color

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules
 .serverless
 package-lock.json
 .yarn-metadata.json
+.DS_Store
 
 # boilerplate-server based apps
 /packages/**/yarn.lock

--- a/packages/components/src/themes/demo.js
+++ b/packages/components/src/themes/demo.js
@@ -40,7 +40,7 @@ module.exports = {
     // Dark context colors
     colorBackgroundDark: "rgb(8, 15, 23)",
     colorBackgroundSecondaryDark: "rgb(11, 23, 34)",
-    colorBackgroundSecondaryTertiaryDark: "rgb(11, 23, 34)",
+    colorBackgroundTertiaryDark: "rgb(11, 23, 34)",
     colorBorderDark: "rgb(11, 23, 34)",
     colorTextDark: "rgb(242, 242, 242)",
     colorRecessDark: "rgb(153, 153, 153)",


### PR DESCRIPTION
Fix demo theme ui color colorBackgroundTertiaryDark.
Add .DS_store to .gitignore for Mac OS convenience.