### PR TITLE
fix: remove sandbox attribute from pattern-demo iframe

### DIFF
--- a/packages/client/src/app/components/pattern/pattern-demo.js
+++ b/packages/client/src/app/components/pattern/pattern-demo.js
@@ -15,7 +15,6 @@ function PatternDemo(props) {
   return <StyledDemo
     src={src}
     referrerpolicy="no-referrer"
-    sandbox="allow-scripts"
     />;
 }
 


### PR DESCRIPTION
Remove sandbox attribute on demo iframe to enable asset loading (e.g. webfonts). 
We had a CORS issue with loading a webfont in a deployment environment.