### PR TITLE
feat: line highlighting in code blocks

### DIFF
--- a/docs/guides/add-component.md
+++ b/docs/guides/add-component.md
@@ -90,7 +90,7 @@ automatically and add **Button** to the components list.
 5. Click on the **Button** item to display its (still blank) demo canvas.
    Replace the contents of `lib/button/demo.js` with the code below:
 
-   ```js
+   ```js{2}
    module.exports = {
      html: () => '<button class="my-button">My first button</button>',
      default: () => {
@@ -110,7 +110,7 @@ automatically and add **Button** to the components list.
 6. Let's throw some `CSS` into the mix.
    Replace the contents of `lib/button/demo.js` with the code below:
 
-   ```js
+   ```js{4-10}
    module.exports = {
      html: () => '<button class="my-button">My first button</button>',
      css: () => `
@@ -137,7 +137,7 @@ Let's count up when clicking on **Button**.
    Replace the contents of `lib/button/demo.js` with the code below:
 
 
-   ```js
+   ```js{13-18}
    module.exports = {
      html: () => '<button class="my-button">My first button</button>',
      css: () => `

--- a/docs/guides/cover.md
+++ b/docs/guides/cover.md
@@ -98,7 +98,7 @@ in the next step.
 
   Add a `.css` export to your `./cover.js` file
 
-  ```js
+  ```js{3-13}
   // cover.js
   module.exports = {
     css: () => {
@@ -124,7 +124,7 @@ in the next step.
 
 2. Add a background gradient to spice things up:
 
-  ```js
+  ```js{7,16}
   // cover.js
   module.exports = {
     css: () => {
@@ -157,7 +157,7 @@ in the next step.
 3. Finally, make the message a link to your component library:
 
 
-  ```js
+  ```js{17-26,33-35}
   // cover.js
   module.exports = {
     css: () => {

--- a/docs/guides/use-widgets.md
+++ b/docs/guides/use-widgets.md
@@ -78,7 +78,7 @@ you do that!
 
 1. Copy your new code block again and replace its language with `widget`.
 
-  ````md
+  ````md{14}
   ## My first code block
   ```js
   const React = require("react");
@@ -116,7 +116,7 @@ you do that!
 
 2. Change the `query` prop of `ComponentList` to `"is=pattern"`
 
-  ````md
+  ````md{8}
   ## My first widget
   ```widget
   const React = require("react");

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -70,6 +70,7 @@
     "hast-to-hyperscript": "^3.0.2",
     "iframe-resizer": "^3.5.16",
     "lodash": "^4.17.4",
+    "parse-numeric-range": "^0.0.2",
     "prop-types": "^15.6.0",
     "query-string": "^6.0.0",
     "react": "16.2.0",

--- a/packages/components/src/code/demo.js
+++ b/packages/components/src/code/demo.js
@@ -3,6 +3,10 @@ const Code = require(".");
 const styled = require("styled-components").default;
 const Themer = require("../demo-themer");
 
+const BASH = `
+npm start
+`;
+
 const JSX = `
 export function Component() {
   // Some comment
@@ -46,7 +50,10 @@ const JSON = `
 module.exports.default = function CodeDemo() {
   return (
     <Themer spacing={true}>
-      <Code block language="jsx">
+      <Code block language="sh">
+        {BASH}
+      </Code>
+      <Code block language="jsx" highlights={[1, 5, 6, 7]}>
         {JSX}
       </Code>
       <Code block language="html">

--- a/packages/components/src/code/index.js
+++ b/packages/components/src/code/index.js
@@ -101,22 +101,23 @@ const StyledLine = styled.div`
   position: relative;
   color: transparent;
 
-  &::after {
-    content: "";
-    position: absolute;
-    left: 50%;
-    right: -50%;
-    top: 0;
-    background: ${BACKGROUND};
-  }
-
+  &::after,
   &::before {
     content: "";
     position: absolute;
+    top: 0;
+    height: 100%;
+    background: ${BACKGROUND};
+  }
+
+  &::after {
+    left: 50%;
+    right: -50%;
+  }
+
+  &::before {
     left: -50%;
     right: 50%;
-    top: 0;
-    background: ${BACKGROUND};
   }
 `;
 

--- a/packages/components/src/markdown/demo.js
+++ b/packages/components/src/markdown/demo.js
@@ -3,6 +3,19 @@ const Themer = require("../demo-themer");
 const Markdown = require(".");
 
 const demoMarkdown = `
+\`\`\`jsx{1,5-7}
+export function Component() {
+  // Some comment
+  return (
+    <div>
+      <div attr="value" attr={value}>
+        <div>Hello there</div>
+      </div>
+    </div>
+  );
+}
+\`\`\`
+
 # This is an h1 tag
 ## This is an h2 tag
 ###### This is an <h6> tag

--- a/packages/components/src/markdown/index.js
+++ b/packages/components/src/markdown/index.js
@@ -1,28 +1,25 @@
-const frontmatter = require('front-matter');
-const React = require('react');
-const remark = require('remark');
-const emoji = require('remark-gemoji-to-emoji');
-const reactRenderer = require('remark-react');
+const frontmatter = require("front-matter");
+const React = require("react");
+const remark = require("remark");
+const emoji = require("remark-gemoji-to-emoji");
+const reactRenderer = require("remark-react");
 const styled = require("styled-components").default;
 const vm = require("vm");
 const resizer = require("iframe-resizer");
+const rangeParser = require("parse-numeric-range");
 
-const MarkdownBlockQuote = require('./markdown-blockquote');
-const MarkdownCode = require('./markdown-code');
-const MarkdownCodeBlock = require('./markdown-code-block');
-const MarkdownCopy = require('./markdown-copy');
-const MarkdownHeadline = require('./markdown-headline');
-const MarkdownHr = require('./markdown-hr');
-const MarkdownImage = require('./markdown-image');
-const MarkdownItem = require('./markdown-item');
-const MarkdownList = require('./markdown-list');
-const MarkdownLink = require('./markdown-link');
+const MarkdownBlockQuote = require("./markdown-blockquote");
+const MarkdownCode = require("./markdown-code");
+const MarkdownCodeBlock = require("./markdown-code-block");
+const MarkdownCopy = require("./markdown-copy");
+const MarkdownHeadline = require("./markdown-headline");
+const MarkdownHr = require("./markdown-hr");
+const MarkdownImage = require("./markdown-image");
+const MarkdownItem = require("./markdown-item");
+const MarkdownList = require("./markdown-list");
+const MarkdownLink = require("./markdown-link");
 
 class Markdown extends React.Component {
-  shouldComponentUpdate(next) {
-    return this.props.source !== next.source;
-  }
-
   render() {
     const { props } = this;
     const Headline = prop("linkable", props.linkable)(MarkdownHeadline);
@@ -48,18 +45,18 @@ class Markdown extends React.Component {
                 li: MarkdownItem,
                 p: MarkdownCopy,
                 pre: preProps => {
-                  const [child = {}] = preProps.children;
+                  const [child = {}] = preProps.children || [];
                   const {props: childProps = {}} = child;
-                  const {className = ''} = childProps;
-                  const type = className.replace(/^language-/, '');
+                  const language = getLanguages(preProps)[0];
+                  const highlights = getHighlights(preProps)[0];
 
-                  switch (type) {
-                    case 'widget': {
+                  switch (language) {
+                    case "widget": {
                       if (typeof props.widgetSrc !== "string") {
                         return null;
                       }
 
-                      const srcdoc= [
+                      const srcdoc = [
                         `<!doctype html>`,
                         `<html>`,
                         `<head>`,
@@ -68,22 +65,27 @@ class Markdown extends React.Component {
                         `<body>`,
                         `<div data-widget-mount></div>`,
                         `<textarea data-widget-state style="display: none;">`,
-                          encodeURIComponent(JSON.stringify({
+                        encodeURIComponent(
+                          JSON.stringify({
                             state: props.widgetState,
-                            code: childProps.children.join('\n')
-                          })),
+                            code: childProps.children.join("\n")
+                          })
+                        ),
                         `</textarea>`,
                         `</body>`,
                         `</html>`
                       ].join("");
 
-                      return <WidgetFrame
-                        srcDoc={srcdoc}
-                        src="/"
-                        />;
+                      return <WidgetFrame srcDoc={srcdoc} src="/" />;
                     }
                     default:
-                      return <MarkdownCodeBlock {...preProps}/>;
+                      return (
+                        <MarkdownCodeBlock
+                          {...preProps}
+                          language={language}
+                          highlights={highlights}
+                        />
+                      );
                   }
                 },
                 ul: is("ul")(MarkdownList),
@@ -100,19 +102,19 @@ class Markdown extends React.Component {
 class WidgetFrame extends React.Component {
   componentDidMount() {
     if (this.ref && !this.resizer) {
-      resizer.iframeResizer({
-        warningTimeout: 0,
-        log: false
-      }, this.ref);
+      resizer.iframeResizer(
+        {
+          warningTimeout: 0,
+          log: false
+        },
+        this.ref
+      );
     }
   }
 
   render() {
-    const {props} = this;
-    return <StyledWidgetFrame
-      innerRef={ref => this.ref = ref}
-      {...props}
-      />;
+    const { props } = this;
+    return <StyledWidgetFrame innerRef={ref => (this.ref = ref)} {...props} />;
   }
 }
 
@@ -159,6 +161,41 @@ function is(is) {
 
 function prop(name, value) {
   return Component => props => <Component {...props} {...{ [name]: value }} />;
+}
+
+function getLanguagePayload({ children }) {
+  const [child] = children;
+
+  if (!child) {
+    return [];
+  }
+
+  const className = child.props.className;
+
+  if (!className) {
+    return [];
+  }
+
+  return className.split(" ").map(n => n.replace("language-", ""));
+}
+
+function getLanguages({ children }) {
+  const payload = getLanguagePayload({ children })
+    .map(n => n.replace(/\{[\d\-,\s]*\}$/, ""))
+    .find(n => typeof n === "string" && n.length > 0)
+
+  if (!payload) {
+    return [];
+  }
+
+  return payload.split(":");
+}
+
+function getHighlights({ children }) {
+  return getLanguagePayload({ children })
+    .map(n => n.match(/\{([\d\-,\s]*)\}$/, ""))
+    .map(n => (n !== null ? n[1] : ""))
+    .map(n => rangeParser.parse(n));
 }
 
 module.exports = Markdown;

--- a/packages/components/src/markdown/markdown-code-block.js
+++ b/packages/components/src/markdown/markdown-code-block.js
@@ -3,37 +3,30 @@ const textContent = require('react-addons-text-content');
 const styled = require("styled-components").default;
 const Code = require('../code');
 
-module.exports = styled(MarkdownCodeBlock)`
-  background: ${props => props.theme.colors.backgroundSecondary};
+module.exports = MarkdownCodeBlock;
+
+const StyledMarkdownCodeBlock = styled.div`
   border-radius: 3px;
   font-size: 15.3px;
   line-height: 23px;
-  padding: 16px;
+  padding: 0 16px;
   margin-bottom: 16px;
+  background: ${props => props.theme.colors.backgroundSecondary};
+  overflow: hidden;
 `;
 
 function MarkdownCodeBlock(props) {
-  const langs = getLanguages(props.children);
   const code = textContent(props.children);
   return (
-    <Code block className={props.className} language={langs[0]}>
-      {code}
-    </Code>
+    <StyledMarkdownCodeBlock>
+      <Code
+        block
+        language={props.language}
+        highlights={props.highlights}
+        height={17}
+        >
+        {code}
+      </Code>
+    </StyledMarkdownCodeBlock>
   );
-}
-
-function getLanguages(children) {
-  const [child] = children;
-  if (!child) {
-    return [];
-  }
-  const className = child.props.className;
-  if (!className) {
-    return [];
-  }
-  return className
-    .split(" ")
-    .map(n => n.replace("language-", ""))
-    .find(n => typeof n === "string" && n.length > 0)
-    .split(":");
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9167,6 +9167,10 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-numeric-range@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/parse-numeric-range/-/parse-numeric-range-0.0.2.tgz#b4f09d413c7adbcd987f6e9233c7b4b210c938e4"
+
 parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"


### PR DESCRIPTION
This enables [Gatsby style](https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/#line-highlighting) line highlighting, e.g.:

    ```js{2}
    module.exports = {
      html: () => '<button class="my-button">My first button</button>',
      default: () => {
        // Nothing implemented yet
      }
    }
    ```

Creates this output:

<img width="756" alt="screen shot 2018-08-17 at 12 58 50" src="https://user-images.githubusercontent.com/4248851/44262967-53e3f600-a21d-11e8-8423-797740b3b2a7.png">

Deployed example: https://patternplate.github.io/preview/248

// cc @frederikreiss 