### PR TITLE
chore: add validate-manifest package

### DIFF
--- a/packages/validate-manifest/build.js
+++ b/packages/validate-manifest/build.js
@@ -1,0 +1,6 @@
+const Fs = require('fs');
+const Schema = require('./lib/schema');
+
+Fs.writeFileSync('./lib/full-schema.json', JSON.stringify(Schema.schema, null, '  '));
+Fs.writeFileSync('./lib/pattern-schema.json', JSON.stringify(Schema.pattern, null, '  '));
+Fs.writeFileSync('./lib/package-schema.json', JSON.stringify(Schema.pkg, null, '  '));

--- a/packages/validate-manifest/index.d.ts
+++ b/packages/validate-manifest/index.d.ts
@@ -1,0 +1,1 @@
+export * from './lib';

--- a/packages/validate-manifest/index.js
+++ b/packages/validate-manifest/index.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib");

--- a/packages/validate-manifest/jest.config.js
+++ b/packages/validate-manifest/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  transform: {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+  testRegex: "src/.*\\.test\\.ts$",
+  moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+  globals: {
+    "ts-jest": {
+      skipBabel: true
+    }
+  }
+};

--- a/packages/validate-manifest/jest.integration.js
+++ b/packages/validate-manifest/jest.integration.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testRegex: "test.integration.js$",
+  moduleFileExtensions: ["js", "jsx", "json", "node"]
+};

--- a/packages/validate-manifest/package.json
+++ b/packages/validate-manifest/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@patternplate/validate-manifest",
+  "version": "3.0.1",
+  "description": "Validate schema for pattern.json",
+  "scripts": {
+    "watch": "concurrently \"yarn tsc -w\" \"yarn watch:schema\"",
+    "watch:schema": "chokidar \"lib/(schema).js\" \"yarn build\"",
+    "deps": "dependency-check . --missing && dependency-check . --extra --no-dev",
+    "build": "tsc && yarn build:schema",
+    "build:schema": "node build && yarn strip",
+    "strip": "cross-env NODE_ENV=production babel lib/schema.js -o lib/schema.js --plugins transform-node-env-inline --plugins minify-dead-code-elimination",
+    "test": "jest",
+    "test:integration": "jest --config jest.integration.js",
+    "prepublishOnly": "yarn build && yarn test:integration"
+  },
+  "typings": "lib/index.d.ts",
+  "files": [
+    "index.js",
+    "lib"
+  ],
+  "xo": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/patternplate/patternplate.git"
+  },
+  "bugs": {
+    "url": "https://github.com/patternplate/patternplate/issues"
+  },
+  "homepage": "https://github.com/patternplate/patternplate#readme",
+  "author": {
+    "name": "Mario Nebl",
+    "email": "mario.nebl@sinnerschrader.com"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.0.0",
+    "@babel/core": "^7.0.0",
+    "@types/jest": "^23.3.1",
+    "@types/node": "^10.9.4",
+    "babel-core": "^6.26.3",
+    "babel-jest": "^23.4.2",
+    "babel-plugin-minify-dead-code-elimination": "^0.4.3",
+    "babel-plugin-transform-node-env-inline": "^0.4.3",
+    "cross-env": "^5.2.0",
+    "dependency-check": "^3.1.0",
+    "jest": "^23.5.0",
+    "ts-jest": "^23.1.4",
+    "ts-node": "^7.0.1",
+    "typescript": "3",
+    "typescript-json-schema": "^0.32.0"
+  },
+  "dependencies": {
+    "schema-utils": "^1.0.0"
+  }
+}

--- a/packages/validate-manifest/src/index.ts
+++ b/packages/validate-manifest/src/index.ts
@@ -1,0 +1,4 @@
+export { validate } from './validate';
+export { isValid } from './is-valid';
+export * from './types';
+export * from './schema';

--- a/packages/validate-manifest/src/is-valid.ts
+++ b/packages/validate-manifest/src/is-valid.ts
@@ -1,0 +1,18 @@
+import { validate } from './validate';
+import * as Schema from "./schema";
+import * as Types from './types';
+
+export function isValid(input: Types.ValidationInput): input is Types.ValidationInput<Types.PatternManifest> {
+  const [, valid] = validate(input);
+  return valid;
+}
+
+export function isValidPatternJson(input: Types.ValidationInput): input is Types.ValidationInput<Types.PatternJson> {
+  const [, valid] = validate(input, Schema.pattern);
+  return valid;
+}
+
+export function isValidPackageJson(input: Types.ValidationInput): input is Types.ValidationInput<Types.PackageJson> {
+  const [, valid] = validate(input, Schema.pkg);
+  return valid;
+}

--- a/packages/validate-manifest/src/schema.ts
+++ b/packages/validate-manifest/src/schema.ts
@@ -1,0 +1,35 @@
+import * as Path from "path";
+
+let fullSchema;
+let patternSchema;
+let packageSchema;
+
+if (!fullSchema && process.env.NODE_ENV !== "production") {
+  fullSchema = computeSchema("PatternManifest");
+  patternSchema = computeSchema("PatternJson");
+  packageSchema = computeSchema("PackageJson");
+
+  function computeSchema(typeName: string): unknown {
+    const TJS = require("typescript-json-schema");
+
+    const fileName =
+      Path.extname(__filename) === ".js"
+        ? require.resolve(`./types.d.ts`)
+        : require.resolve(`./types.ts`);
+
+    const program = TJS.getProgramFromFiles([fileName]);
+
+    return TJS.generateSchema(program, typeName, {
+      required: true,
+      strictNullChecks: true
+    });
+  }
+} else {
+  fullSchema = require("./full-schema.json");
+  patternSchema = require("./pattern-schema.json");
+  packageSchema = require("./package-schema.json");
+}
+
+export const schema = fullSchema;
+export const pattern = patternSchema;
+export const pkg = packageSchema;

--- a/packages/validate-manifest/src/types.ts
+++ b/packages/validate-manifest/src/types.ts
@@ -1,0 +1,80 @@
+export interface ValidationInput<T = unknown> {
+  target: T;
+  name: string;
+}
+
+export type PatternManifest =
+  | PatternJson
+  | PackageJson;
+
+export interface PatternJson {
+  /**
+   * The pattern's unique name
+   * @minLength 1
+   * @maxLength 214
+   * @pattern ^(?:\.[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$
+   */
+  name: string;
+
+  /**
+   * The semver version of the pattern
+   * @minLength 1
+   * @maxLength 214
+   * @pattern ^\d+\.\d+\.\d+(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?
+   */
+  version: string;
+
+  /**
+   * The name used for display of the pattern
+   * @minLength 1
+   * @maxLength 214
+   */
+  displayName?: string;
+
+  /**
+   * Short description of the pattern
+   * @maxLength 512
+   */
+  description?: string;
+
+  /**
+   * List of querieable tags
+   */
+  tags?: string[];
+}
+
+export interface PackageJson {
+  /**
+   * The pattern's unique name
+   * @minLength 1
+   * @maxLength 214
+   * @pattern ^(?:\.[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$
+   */
+  name: string;
+
+  /**
+   * The semver version of the pattern
+   * @minLength 1
+   * @maxLength 214
+   * @pattern ^\d+\.\d+\.\d+(?:-[\da-z\-]+(?:\.[\da-z\-]+)*)?(?:\+[\da-z\-]+(?:\.[\da-z\-]+)*)?
+   */
+  version: string;
+
+  /**
+   * The name used for display of the pattern
+   * @minLength 1
+   * @maxLength 214
+   */
+  displayName?: string;
+
+  /**
+   * Short description of the pattern
+   * @maxLength 512
+   */
+  description?: string;
+
+  /**
+   * Fields specific for patternplate
+   */
+  patternplate: PatternJson;
+}

--- a/packages/validate-manifest/src/validate.test.ts
+++ b/packages/validate-manifest/src/validate.test.ts
@@ -1,0 +1,102 @@
+import { validate } from '.';
+
+test('should fail for empty target', () => {
+  const [, valid] = validate({
+    name: 'test',
+    target: {}
+  });
+
+  expect(valid).toBe(false);
+});
+
+test('should pass for minimal props', () => {
+  const [err, valid] = validate({
+    name: 'test',
+    target: {
+      name: 'a',
+      version: '1.0.0'
+    }
+  });
+
+  expect(valid).toBe(true);
+  expect(err).toBeNull();
+});
+
+test('should fail for missing name', () => {
+  const [err, valid] = validate({
+    name: 'test',
+    target: {
+      version: '1'
+    }
+  });
+
+  expect(valid).toBe(false);
+  expect(err.message).toContain('required property \'name\'');
+});
+
+test('should fail for missing version', () => {
+  const [err, valid] = validate({
+    name: 'test',
+    target: {
+      name: 'a'
+    }
+  });
+
+  expect(valid).toBe(false);
+  expect(err.message).toContain('required property \'version\'');
+});
+test('should fail for mismatched version', () => {
+  const [err, valid] = validate({
+    name: 'test',
+    target: {
+      name: 'a',
+      version: 3
+    }
+  });
+
+  expect(valid).toBe(false);
+  expect(err.message).toContain('options.version should be string');
+});
+
+test('should fail for invalid semver', () => {
+  const [err, valid] = validate({
+    name: 'test',
+    target: {
+      name: 'a',
+      version: 'foo'
+    }
+  });
+
+  expect(valid).toBe(false);
+  expect(err.message).toContain('options.version should');
+});
+
+test('should fail for empty name', () => {
+  const [err, valid] = validate({
+    name: 'test',
+    target: {
+      name: '',
+      version: '1.0.0'
+    }
+  });
+
+  expect(valid).toBe(false);
+  expect(err.message).toContain('options.name should');
+});
+
+
+test('should fail for empty displayName', () => {
+  const [err, valid] = validate({
+    name: 'test',
+    target: {
+      name: 'a',
+      displayName: '',
+      version: '1.0.0'
+    }
+  });
+
+  expect(valid).toBe(false);
+  expect(err.message).toContain('options.displayName should');
+});
+
+

--- a/packages/validate-manifest/src/validate.ts
+++ b/packages/validate-manifest/src/validate.ts
@@ -1,0 +1,17 @@
+import * as Schema from "./schema";
+import { ValidationInput } from "./types";
+
+const validateOptions = require("schema-utils");
+
+export function validate(
+  { target, name }: ValidationInput,
+  schema: unknown = Schema.schema
+): [Error, false] | [null, true] {
+  try {
+    validateOptions(schema, target, name);
+  } catch (err) {
+    return [err, false];
+  }
+
+  return [null, true];
+}

--- a/packages/validate-manifest/test/test.integration.js
+++ b/packages/validate-manifest/test/test.integration.js
@@ -1,0 +1,30 @@
+const { validate } = require("..");
+const TJS = require("typescript-json-schema");
+
+jest.mock("typescript-json-schema");
+
+test("should fail as expected with built json schema", () => {
+  const [, valid] = validate({
+    name: "test",
+    target: {}
+  });
+
+  expect(valid).toBe(false);
+});
+
+test("should not call TJS", () => {
+  expect(TJS.generateSchema).not.toHaveBeenCalled();
+});
+
+test("should succeed as expected with built json schema", () => {
+  const [err, valid] = validate({
+    name: "test",
+    target: {
+      name: "",
+      version: ""
+    }
+  });
+
+  expect(err).toBeNull();
+  expect(valid).toBe(true);
+});

--- a/packages/validate-manifest/tsconfig.json
+++ b/packages/validate-manifest/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "outDir": "lib",
+    "sourceMap": true,
+    "module": "commonjs",
+    "target": "es2015",
+    "declaration": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "exclude": [
+    "src/**/*.test.ts"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -666,6 +666,13 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
+"@patternplate/deploy-site@file:./packages/deploy":
+  version "2.5.18"
+  dependencies:
+    "@marionebl/sander" "^0.6.1"
+    execa "^0.9.0"
+    meow "^4.0.0"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"


### PR DESCRIPTION
This adds the `validate-manifest` package intended to ensure passed data from `pattern.json` and `package.json` files conforms to the intended data structures. 

This is achieved by reading types from TypeScript sources and transforming them to JSONSchema on the fly and then feeding `schema-utils` with both the derived schema and data to validate. 

For production builds the derived schemas are written to disk and read from there instead.