### PR TITLE
chore: migrate build to typescript project references

### DIFF
--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,5 +1,12 @@
 {
+  "references": [
+    {"path": "../validate-config"}
+  ],
   "compilerOptions": {
+    "composite": true,
+    "declarationMap": true,
+    "moduleResolution": "node",
+    "rootDir": "./src",
     "outDir": "lib",
     "sourceMap": true,
     "module": "commonjs",

--- a/packages/validate-config/tsconfig.json
+++ b/packages/validate-config/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "composite": true,
+    "declarationMap": true,
+    "rootDir": "./src",
+    "moduleResolution": "node",
     "outDir": "lib",
     "sourceMap": true,
     "module": "commonjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "include": [],
+  "references": [
+    {"path": "./packages/api"}
+  ]
+}


### PR DESCRIPTION
This PR migrates from different watch tasks per module in the monorepo
to a build setup leveraging typescript project references.
This will benefit the compile time and the simplicity for developers.

All which should be required to compile patternplate with all its
required dependenies should be `yarn tsc -b`.
This will compile all required, outdated packages and nothing more.
To start in watch mode just an added `-w` is required.

To see a bit more of whats happening inside, execute
`yarn tsc -b --verbose`. This will output a lot more details.

Current state:

* [x] just `api` and `validate-config` have references
* [ ] investigate on how to execute different scripts for some packages
* [ ] packages need to be migrated to typescript
