### PR TITLE
refactor: rework linking

### DIFF
--- a/components/legacy/src/main-navigation/index.js
+++ b/components/legacy/src/main-navigation/index.js
@@ -1,6 +1,5 @@
 const React = require("react");
 const styled = require("styled-components").default;
-const Link = require("../link");
 const Header = require("../main-header");
 const NavigationTree = require("../navigation-tree");
 const NavigationToolbar = require("../navigation-toolbar");

--- a/components/next-generation/markdown/src/markdown-components/markdown-link.tsx
+++ b/components/next-generation/markdown/src/markdown-components/markdown-link.tsx
@@ -1,17 +1,15 @@
 import * as React from "react";
 import styled from "styled-components";
+import { Link } from "@patternplate/component-link";
 import * as Url from "url";
 import * as queryString from "query-string";
-import { Link } from "@patternplate/component-link";
 
 export const MarkdownLink = (props) => {
-  const parsed = Url.parse(props.href || "./");
   const abs = absolute(props.href);
-  const href = abs ? props.href : [parsed.pathname, parsed.hash].join("");
-  const query = abs ? {} : queryString.parse(parsed.query);
+  const query = abs ? {} : queryString.parse(Url.parse(props.href).query);
 
   return (
-    <StyledLink external={abs} hint href={href} query={query}>
+    <StyledLink hint href={props.href} query={query}>
       {props.children}
     </StyledLink>
   );
@@ -31,6 +29,7 @@ const StyledLink = styled(Link)`
     text-decoration: underline;
   }
 `;
+
 
 function absolute(href) {
   const parsed = Url.parse(href || "./");

--- a/docs/advanced/build.md
+++ b/docs/advanced/build.md
@@ -243,7 +243,7 @@ the ubiquitous in the JavaScript ecosystem at the time of writing.
   yarn babel -w
   ```
 
-4. Access your button component at [localhost:1337/pattern/button](http://localhost:1337/pattern/button).
+4. Access your button component at `http://localhost:1337/pattern/button`.
    If you used `patternplate` before this should be familiar:
 
   ![](https://patternplate.github.io/media/images/screenshot-build.svg)
@@ -285,5 +285,5 @@ the ubiquitous in the JavaScript ecosystem at the time of writing.
 
 ## Related topics
 
-* [CLI](./doc/docs/reference/cli?reference-enabled=true)
+* [CLI](../reference/cli?reference-enabled=true)
 

--- a/docs/advanced/deploy.md
+++ b/docs/advanced/deploy.md
@@ -28,12 +28,12 @@ We will …
 
 ## You'll need
 
-* :white_check_mark: You are all set if you followed along [Guide: Build a component](./doc/docs/guides/add-component?guides-enabled=true)
+* :white_check_mark: You are all set if you followed along [Guide: Build a component](../guides/add-component?guides-enabled=true)
 
 ---
 
 * :writing_hand: Text editor
-* :file_folder: patternplate project ([Getting Started Guide](./doc/docs/guides/getting-started?guides-enabled=true))
+* :file_folder: patternplate project ([Getting Started Guide](../guides/getting-started?guides-enabled=true))
 
 ## Before you start
 
@@ -146,5 +146,5 @@ to hit the save button next to the dropdown.
 
 ## Related topics
 
-* [CLI](./doc/docs/reference/cli?reference-enabled=true)
+* [CLI](../reference/cli?reference-enabled=true)
 

--- a/docs/advanced/theming.md
+++ b/docs/advanced/theming.md
@@ -22,7 +22,7 @@ There are three types of theming configuration:
 
 ## Related topics
 
-* [Configuration](./doc/docs/reference/configuration?reference-enabled=true)
+* [Configuration](../reference/configuration?reference-enabled=true)
 
 
 ## Theming playground

--- a/docs/guides/add-component.md
+++ b/docs/guides/add-component.md
@@ -27,12 +27,12 @@ We will …
 
 ## You'll need
 
-* :white_check_mark: You are all set if you followed along [Guide: Getting Started](./doc/docs/guides/add-component?guides-enabled=true)
+* :white_check_mark: You are all set if you followed along [Guide: Getting Started](./getting-started?guides-enabled=true)
 
 ---
 
 * :writing_hand: Text editor
-* :file_folder: patternplate project ([Getting Started Guide](./doc/docs/guides/getting-started?guides-enabled=true))
+* :file_folder: patternplate project ([Getting Started Guide](./getting-started?guides-enabled=true))
 
 ## Create a new pattern
 
@@ -101,7 +101,7 @@ automatically and add **Button** to the components list.
   
   > :information_source: You might think: HTML in JavaScript. What is this, sorcery? 
   > Don't worry, you can place your HTML in distinct files (demo.html) just fine, too.
-  > The same goes for your CSS (demo.css). See [Demos](./doc/docs/reference/demos?guides-enabled=true&reference-enabled=true#multi-file-demos) for details.
+  > The same goes for your CSS (demo.css). See [Demos](../reference/demos?guides-enabled=true&reference-enabled=true#multi-file-demos) for details.
 
    Saving the file signals the **Button** demo to reload automatically and display the `HTML` you just added.
 
@@ -171,14 +171,14 @@ Let's count up when clicking on **Button**.
 * `demo.js` provides `HTML`, `CSS` and JavaScript via the `html`, `css` and `default` exports 
 
   > :information_source: Traditional multi file components work, too. 
-  > See [Demos](./doc/docs/reference/demos?guides-enabled=true&reference-enabled=true#multi-file-demos) for details.
+  > See [Demos](../reference/demos?guides-enabled=true&reference-enabled=true#multi-file-demos) for details.
 
 * Changes on source files cause demos to reload automatically
 
 ## Up next
 
-* [Guide: Write documentation](./doc/docs/guides/write-documentation?guides-enabled=true)
+* [Guide: Write documentation](./write-documentation?guides-enabled=true)
 
 ## Related topics
 
-* [Demos](./doc/docs/reference/demos?reference-enabled=true)
+* [Demos](../reference/demos?reference-enabled=true)

--- a/docs/guides/cover.md
+++ b/docs/guides/cover.md
@@ -28,12 +28,12 @@ We will …
 
 ## You'll need
 
-* :white_check_mark: You are all set if you followed along [Guide: Build a component](./doc/docs/guides/add-component?guides-enabled=true)
+* :white_check_mark: You are all set if you followed along [Guide: Build a component](./add-component?guides-enabled=true)
 
 ---
 
 * :writing_hand: Text editor
-* :file_folder: patternplate project ([Getting Started Guide](./doc/docs/guides/getting-started?guides-enabled=true))
+* :file_folder: patternplate project ([Getting Started Guide](./getting-started?guides-enabled=true))
 
 ## Before you start
 
@@ -41,12 +41,12 @@ We will …
 
 ## Configure patternplate
 
-1. Make sure `patternplate` runs on [localhost:1337](http://localhost:1337) 
+1. Make sure `patternplate` runs on `http://localhost:1337/`
 
 2. Create a `./patternplate.config.js` and copy the following code into it. We are configuring `patternplate` with its defaults to prepare for the next step.
 
   > :information_source: 
-  > See [Reference: Configuration](./doc/docs/reference/configuration) for details about the config keys
+  > See [Reference: Configuration](../reference/configuration) for details about the config keys
 
 ```js
 // patternplate.config.js, default config
@@ -84,7 +84,7 @@ module.exports = {
 };
 ```
 
-5. Navigate to [localhost:1337/?reload=true](http://localhost:1337/?reload=true) and see the main staple of  tutorial writers world wide, the all-popular **Hello world** message:
+5. Navigate to `http://localhost:1337/?reload=true` and see the main staple of  tutorial writers world wide, the all-popular **Hello world** message:
 
   ![](https://patternplate.github.io/media/images/screenshot-cover.svg)
 
@@ -212,8 +212,8 @@ in the next step.
 
   > :information_source: Conceptually covers are specialized demo entries. 
   > 
-  > See [Reference: Demos](./doc/docs/reference/demos) for more details about supported exports, etc.
+  > See [Reference: Demos](../reference/demos) for more details about supported exports, etc.
 
 ## Related topics
 
-* [Demos](./doc/docs/reference/demos?reference-enabled=true)
+* [Demos](../reference/demos?reference-enabled=true)

--- a/docs/guides/getting-started-app.md
+++ b/docs/guides/getting-started-app.md
@@ -10,7 +10,7 @@ options:
 > :information_source: 
 > Looking to set up patternplate as a dev project? 
 > 
-> [Give the CLI Getting Started Guide a go](./doc/docs/guides/getting-started?guides-enabled=true).
+> [Give the CLI Getting Started Guide a go](./getting-started?guides-enabled=true).
 
 # Get started with @patternplate/app
 
@@ -104,8 +104,8 @@ That's it for this guide – you just cloned and started your very first `patte
 
 ## Up next
 
-* [Guide: Build a component](./doc/docs/guides/add-component?guides-enabled=true)
+* [Guide: Build a component](./add-component?guides-enabled=true)
 
 ## Related topics
 
-* [CLI](./doc/docs/reference/cli?reference-enabled=true)
+* [CLI](../reference/cli?reference-enabled=true)

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -9,7 +9,7 @@ options:
 
 > :information_source: 
 > You don't want/need to use the CLI?  
-> [Check out our app and let the machine deal with Node.js and GIT](./doc/docs/guides/getting-started-app?guides-enabled=true).
+> [Check out our app and let the machine deal with Node.js and GIT](./getting-started-app?guides-enabled=true).
 
 # Your kickstart into patternplate
 
@@ -78,7 +78,7 @@ You should see a small loading spinner in your terminal.
 
 ## 3. Access the web interface
 
-You can access the web interface of your patternplate project at [localhost:1337](http://localhost:1337/?guides-enabled=true).
+You can access the web interface of your patternplate project at `http://localhost:1337/?guides-enabled=true`.
 
 If everything worked `patternplate` greets you with this screen:
 
@@ -89,16 +89,16 @@ If everything worked `patternplate` greets you with this screen:
 
 * There is `create-patternplate`, a command line program that helps with boostrapping patternplate quickly.
 
-* `patternplate` provides a command line interface. The default command is `start`, which brings up the web interface on [localhost:1337](http://localhost:1337/?guides-enabled=true).
+* `patternplate` provides a command line interface. The default command is `start`, which brings up the web interface on `http://localhost:1337/?guides-enabled=true`.
 
 
 ## Up next
 
-* [Guide: Build a component](./doc/docs/guides/add-component?guides-enabled=true)
+* [Guide: Build a component](./add-component?guides-enabled=true)
 
 ## Related topics
 
-* [CLI](./doc/docs/guides/add-component?reference-enabled=true&guides-enabled=true)
+* [CLI](../reference/cli?reference-enabled=true&guides-enabled=true)
 
 ## Shortcut
 

--- a/docs/guides/use-widgets.md
+++ b/docs/guides/use-widgets.md
@@ -24,11 +24,11 @@ We will …
 
 ## You'll need
 
-* :white_check_mark: You are all set if you followed along [Guide: Build a component](./doc/docs/guides/add-component?guides-enabled=true)
+* :white_check_mark: You are all set if you followed along [Guide: Build a component](./add-component?guides-enabled=true)
 ---
 
 * :writing_hand: Text editor
-* :file_folder: patternplate project ([Getting Started Guide](./doc/docs/guides/getting-started?guides-enabled=true))
+* :file_folder: patternplate project ([Getting Started Guide](./getting-started?guides-enabled=true))
 
 ## Before you start
 
@@ -168,11 +168,11 @@ you do that!
 
 ## Up next
 
-* [Guide: Convince with a cover](./doc/docs/guides/cover?guides-enabled=true)
+* [Guide: Convince with a cover](./cover?guides-enabled=true)
 
 
 ## Related topics
 
-* [Documentation](./doc/docs/reference/documentation?reference-enabled=true)
-* [Search](./doc/docs/reference/search?reference-enabled=true)
-* [Widgets](./doc/docs/reference/widgets?reference-enabled=true)
+* [Documentation](../reference/documentation?reference-enabled=true)
+* [Search](../reference/search?reference-enabled=true)
+* [Widgets](../reference/widgets?reference-enabled=true)

--- a/docs/guides/virtual-folders.md
+++ b/docs/guides/virtual-folders.md
@@ -28,11 +28,11 @@ We will …
 
 ## You'll need
 
-* :white_check_mark: You are all set if you followed along [Guide: Build a component](./doc/docs/guides/add-component?guides-enabled=true)
+* :white_check_mark: You are all set if you followed along [Guide: Build a component](./add-component?guides-enabled=true)
 ---
 
 * :writing_hand: Text editor
-* :file_folder: patternplate project ([Getting Started Guide](./doc/docs/guides/getting-started?guides-enabled=true))
+* :file_folder: patternplate project ([Getting Started Guide](./getting-started?guides-enabled=true))
 
 ## Before you start
 
@@ -128,7 +128,7 @@ in a second.
    This time around we matched only **Button** and **Hello-World**. That happens because they have both
    the tag `world` attached, while the **my-patternplate** item does not.
 
-   Visit the [search reference](./doc/docs/reference/search?reference-enabled=true) for detailed information about search queries.
+   Visit the [search reference](../reference/search?reference-enabled=true) for detailed information about search queries.
 
 ## Create a virtual folder
 
@@ -184,10 +184,10 @@ So we'll add a new file there:
 
 ## Up next
 
-* [Guide: Enhance docs with widgets](./doc/docs/guides/use-widgets?guides-enabled=true)
+* [Guide: Enhance docs with widgets](./use-widgets?guides-enabled=true)
 
 
 ## Related topics
 
-* [Documentation](./doc/docs/reference/documentation?reference-enabled=true)
-* [Search](./doc/docs/reference/search?reference-enabled=true)
+* [Documentation](../reference/documentation?reference-enabled=true)
+* [Search](../reference/search?reference-enabled=true)

--- a/docs/guides/write-documentation.md
+++ b/docs/guides/write-documentation.md
@@ -28,12 +28,12 @@ We will …
 
 ## You'll need
 
-* :white_check_mark: You are all set if you followed along [Guide: Build a component](./doc/docs/guides/add-component?guides-enabled=true)
+* :white_check_mark: You are all set if you followed along [Guide: Build a component](./add-component?guides-enabled=true)
 
 ---
 
 * :writing_hand: Text editor
-* :file_folder: patternplate project ([Getting Started Guide](./doc/docs/guides/getting-started?guides-enabled=true))
+* :file_folder: patternplate project ([Getting Started Guide](./getting-started?guides-enabled=true))
 
 ## Before you start
 
@@ -64,7 +64,7 @@ counts up. Let's tell the consumers of our component library about this.
   Clicking on a the text will count up from 1
   ```
 
-4. Navigate to [localhost:1337/pattern/hello-world](http://localhost:1337/pattern/hello-world?navigation-enabled=true&components-enabled=true) and scroll down: Your small description has been rendered below the component demo.
+4. Navigate to `http://localhost:1337/pattern/hello-world?navigation-enabled=true&components-enabled=true` and scroll down: Your small description has been rendered below the component demo.
 
 ![](https://patternplate.github.io/media/images/screenshot-docs.svg)
 
@@ -150,10 +150,10 @@ at the beginning of `README.md`.
 
 ## Up next
 
-* [Guide: Create Virtual Folders](./doc/docs/guides/virtual-folders?guides-enabled=true)
+* [Guide: Create Virtual Folders](./virtual-folders?guides-enabled=true)
 
 
 ## Related topics
 
-* [Documentation](./doc/docs/reference/documentation?reference-enabled=true)
-* [Demos](./doc/docs/reference/demos?reference-enabled=true)
+* [Documentation](../reference/documentation?reference-enabled=true)
+* [Demos](../reference/demos?reference-enabled=true)

--- a/docs/reference/documentation.md
+++ b/docs/reference/documentation.md
@@ -95,8 +95,8 @@ Markdown in `patternplate` can highlight the following languages:
 
 ## Related
 
-* [Reference: Configuration](./doc/docs/reference/configuration)
-* [Reference: Widgets](./doc/docs/reference/widgets)
+* [Reference: Configuration](../reference/configuration)
+* [Reference: Widgets](../reference/widgets)
 
 [frontmatter]: https://jekyllrb.com/docs/frontmatter/
 [github-flavored-markdown]: https://guides.github.com/features/mastering-markdown/

--- a/docs/why.md
+++ b/docs/why.md
@@ -6,8 +6,8 @@ options:
 
 > :information_source: 
 > Already sold on patternplate and want to know **how** things work instead of **why** we built them? This way: 
-> * [Develop in patternplate with the CLI](./doc/docs/guides/getting-started?guides-enabled=true)
-> * [View your component library via @patternplate/app](./doc/docs/guides/getting-started-app?guides-enabled=true)
+> * [Develop in patternplate with the CLI](./guides/getting-started?guides-enabled=true)
+> * [View your component library via @patternplate/app](./guides/getting-started-app?guides-enabled=true)
 
 # Create better Design Systems
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@marionebl/ttypescript": "^1.5.6",
     "@patternplate/deploy-site": "file:./packages/deploy",
+    "broken-link-checker": "^0.7.8",
     "dom-to-image": "^2.6.0",
     "eslint": "^4.9.0",
     "eslint-config-prettier": "^2.4.0",

--- a/packages/cli/src/build/index.js
+++ b/packages/cli/src/build/index.js
@@ -70,9 +70,9 @@ async function build({flags}) {
 
   await Promise.all(pool.map(async item => {
     const full = `${base}${item.contentType}/${item.id}`;
-    const html = await render(full, state);
+    const rendering = await render(full, state);
     const target = path.join(out, item.contentType, `${item.id}.html`);
-    await sander.writeFile(target, html);
+    await sander.writeFile(target, rendering.contents);
   }));
 
   // Create required client js bundles

--- a/packages/cli/src/build/index.js
+++ b/packages/cli/src/build/index.js
@@ -71,7 +71,7 @@ async function build({flags}) {
   await Promise.all(pool.map(async item => {
     const full = `${base}${item.contentType}/${item.id}`;
     const html = await render(full, state);
-    const target = path.join(out, item.contentType, item.id, 'index.html');
+    const target = path.join(out, item.contentType, `${item.id}.html`);
     await sander.writeFile(target, html);
   }));
 

--- a/packages/client/src/app/containers/documentation.js
+++ b/packages/client/src/app/containers/documentation.js
@@ -100,7 +100,7 @@ const selectDisplayName = createSelector(
   }
 );
 
-const selectType = createSelector(selectItem, match => {
+export const selectType = createSelector(selectItem, match => {
   if (match && match.contents) {
     return "doc";
   }

--- a/packages/client/src/app/containers/link.js
+++ b/packages/client/src/app/containers/link.js
@@ -1,4 +1,5 @@
 import url from "url";
+import Path from "path";
 import queryString from "querystring";
 import { Link } from "@patternplate/components";
 import { pickBy } from "lodash";
@@ -12,7 +13,7 @@ export default connect(mapState, mapDispatch)(Link.RawLink);
 function mapState(state, own) {
   const location = state.routing.locationBeforeTransitions;
   return Object.assign({}, own,
-    {href: getHref(own, { base: state.base, location })}
+    { href: getHref(own, { base: state.base, location }) }
   );
 }
 
@@ -45,9 +46,9 @@ function getHref(props, context) {
   const parsed = props.href
     ? url.parse(props.href)
     : {
-        pathname: context.location.pathname,
-        query: queryString.stringify(context.location.query)
-      };
+      pathname: context.location.pathname,
+      query: queryString.stringify(context.location.query)
+    };
 
   parsed.query = queryString.parse(parsed.query);
 
@@ -75,6 +76,17 @@ function getHref(props, context) {
         return value !== "false" && value !== "0" && !!(value);
       }
     );
+
+  if (
+    parsed.pathname &&
+    (parsed.pathname.includes("pattern") ||
+      parsed.pathname.includes("doc/docs"))
+  ) {
+    parsed.pathname = `${Path.dirname(parsed.pathname)}/${Path.basename(
+      parsed.pathname,
+      Path.extname(parsed.pathname)
+    )}.html`;
+  }
 
   const pathname =
     typeof parsed.pathname === "string"

--- a/packages/client/src/app/selectors/relation.js
+++ b/packages/client/src/app/selectors/relation.js
@@ -8,7 +8,7 @@ export default function createRelationSelector(key, selectItem) {
       return [];
     }
     return (item[key] || [])
-      .map(id => find(patterns, `pattern/${id}`, { type: "pattern" }))
+      .map(id => find(patterns, `pattern/${id}.html`, { type: "pattern" }))
       .filter(Boolean);
   });
 }

--- a/packages/client/src/app/server.js
+++ b/packages/client/src/app/server.js
@@ -11,6 +11,7 @@ import { ServerStyleSheet } from "@patternplate/components";
 
 import routes from "./routes";
 import configureStore from "./store";
+import selectItem from "./selectors/item";
 
 export default function(location, data) {
   const sheet = new ServerStyleSheet();
@@ -34,9 +35,13 @@ export default function(location, data) {
             <RouterContext {...props} />
           </Provider>
         );
+
+        const state = store.getState();
+        const item = selectItem(state);
+
         const html = renderToString(context);
         const css = sheet.getStyleElement();
-        resolve({ html, css });
+        resolve({ html, css, status: typeof item !== 'undefined' ? 200 : 404 });
       }
     );
   });

--- a/packages/client/src/app/utils/find.js
+++ b/packages/client/src/app/utils/find.js
@@ -17,9 +17,11 @@ function find(tree, id, { type }) {
     .filter(Boolean);
 
   const match = tree.children.find(
-    child =>
-      child.path.every((s, i) => frags[i] === s) &&
+    child => {
+      console.log(child);
+      (child.path || []).every((s, i) => frags[i] === s) &&
       (child.type === type || child.type === "folder")
+    }
   );
 
   return match;

--- a/packages/client/src/app/utils/get-id-by-pathname.js
+++ b/packages/client/src/app/utils/get-id-by-pathname.js
@@ -3,5 +3,10 @@ import urlQuery from "./url-query";
 
 export default function getIdByPathname(pathname, base = "/") {
   const parsed = urlQuery.parse(pathname);
-  return (path.posix || path).relative(base, parsed.pathname);
+  const fragments = (path.posix || path)
+    .relative(base, parsed.pathname)
+    .split("/");
+
+  const last = fragments.pop();
+  return [...fragments, path.basename(last, path.extname(last))].join("/");
 }

--- a/packages/client/src/server.js
+++ b/packages/client/src/server.js
@@ -7,7 +7,6 @@ const express = require("express");
 const serve = require("serve-static");
 const fetch = require("isomorphic-fetch");
 const cors = require("cors");
-
 const render = require("./render");
 
 module.exports = client;
@@ -67,13 +66,14 @@ async function main(options) {
 
       const tree = {id: "root", children: patterns};
 
-      res.send(
-        await render(req.url, {
-          schema: { meta: tree, docs },
-          config: options.config,
-          base,
-        })
-      );
+      const rendering = await render(req.url, {
+        schema: { meta: tree, docs },
+        config: options.config,
+        base,
+      });
+
+      res.status(rendering.status);
+      res.send(rendering.contents);
     } catch (err) {
       next(err);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,7 +1248,7 @@
     glob-to-regexp "^0.3.0"
 
 "@patternplate/deploy-site@file:./packages/deploy":
-  version "3.0.6"
+  version "3.1.1"
   dependencies:
     "@marionebl/sander" "^0.6.1"
     execa "^0.9.0"
@@ -2866,6 +2866,26 @@ bel@^5.1.5:
     is-electron "^2.0.0"
     pelo "^0.0.4"
 
+bhttp@^1.2.1:
+  version "1.2.4"
+  resolved "https://registry.npmjs.org/bhttp/-/bhttp-1.2.4.tgz#fed0c24f765b35afc4940b08ab3214813e38f38f"
+  integrity sha1-/tDCT3ZbNa/ElAsIqzIUgT44848=
+  dependencies:
+    bluebird "^2.8.2"
+    concat-stream "^1.4.7"
+    debug "^2.1.1"
+    dev-null "^0.1.1"
+    errors "^0.2.0"
+    extend "^2.0.0"
+    form-data2 "^1.0.0"
+    form-fix-array "^1.0.0"
+    lodash "^2.4.1"
+    stream-length "^1.0.2"
+    string "^3.0.0"
+    through2-sink "^1.0.0"
+    through2-spy "^1.2.0"
+    tough-cookie "^2.3.1"
+
 big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
@@ -2883,6 +2903,11 @@ block-stream@*:
   resolved "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+bluebird@^2.3.5, bluebird@^2.6.2, bluebird@^2.8.1, bluebird@^2.8.2:
+  version "2.11.0"
+  resolved "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+  integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
 bluebird@^3.5.1:
   version "3.5.1"
@@ -3000,6 +3025,34 @@ braces@^2.3.1:
     snapdragon-node "^2.0.1"
     split-string "^3.0.2"
     to-regex "^3.0.1"
+
+broken-link-checker@^0.7.8:
+  version "0.7.8"
+  resolved "http://registry.npmjs.org/broken-link-checker/-/broken-link-checker-0.7.8.tgz#47ea837e1b43ec2feac220207dc3f44c03b49ec0"
+  integrity sha512-/zH4/nLMNKDeDH5nVuf/R6WYd0Yjnar1NpcdAO2+VlwjGKzJa6y42C03UO+imBSHwe6BefSkVi82fImE2Rb7yg==
+  dependencies:
+    bhttp "^1.2.1"
+    calmcard "~0.1.1"
+    chalk "^1.1.3"
+    char-spinner "^1.0.1"
+    condense-whitespace "^1.0.0"
+    default-user-agent "^1.0.0"
+    errno "~0.1.4"
+    extend "^3.0.0"
+    http-equiv-refresh "^1.0.0"
+    humanize-duration "^3.9.1"
+    is-stream "^1.0.1"
+    is-string "^1.0.4"
+    limited-request-queue "^2.0.0"
+    link-types "^1.1.0"
+    maybe-callback "^2.1.0"
+    nopter "~0.3.0"
+    parse5 "^3.0.2"
+    robot-directives "~0.3.0"
+    robots-txt-guard "~0.1.0"
+    robots-txt-parse "~0.0.4"
+    urlcache "~0.7.0"
+    urlobj "0.0.11"
 
 brorand@^1.0.1:
   version "1.1.0"
@@ -3242,7 +3295,7 @@ caller-callsite@^2.0.0:
   dependencies:
     callsites "^2.0.0"
 
-caller-path@^0.1.0:
+caller-path@^0.1.0, caller-path@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
   dependencies:
@@ -3261,6 +3314,11 @@ callsites@^0.2.0:
 callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
+
+calmcard@~0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/calmcard/-/calmcard-0.1.1.tgz#35ac2b66492b0ed39ad06a893a0ff6e61124e449"
+  integrity sha1-NawrZkkrDtOa0GqJOg/25hEk5Ek=
 
 camel-case@3.0.x:
   version "3.0.0"
@@ -3341,7 +3399,7 @@ chain-function@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz#0d4ab37e7e18ead0bdc47b920764118ce58733dc"
 
-chalk@0.5.1:
+chalk@0.5.1, chalk@~0.5.1:
   version "0.5.1"
   resolved "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz#663b3a648b68b55d04690d49167aa837858f2174"
   dependencies:
@@ -3408,6 +3466,11 @@ chalk@~0.4.0:
     ansi-styles "~1.0.0"
     has-color "~0.1.0"
     strip-ansi "~0.1.0"
+
+char-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz#e6ea67bd247e107112983b7ab0479ed362800081"
+  integrity sha1-5upnvSR+EHESmDt6sEee02KAAIE=
 
 character-entities-html4@^1.0.0:
   version "1.1.1"
@@ -3558,7 +3621,7 @@ cli-table2@^0.2.0:
   optionalDependencies:
     colors "^1.1.2"
 
-cli-table@^0.3.1:
+cli-table@^0.3.1, cli-table@~0.3.1:
   version "0.3.1"
   resolved "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
   dependencies:
@@ -3765,6 +3828,15 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
+combined-stream2@^1.0.2:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/combined-stream2/-/combined-stream2-1.1.2.tgz#f6e14b7a015666f8c7b0a1fac506240164ac3570"
+  integrity sha1-9uFLegFWZvjHsKH6xQYkAWSsNXA=
+  dependencies:
+    bluebird "^2.8.1"
+    debug "^2.1.1"
+    stream-length "^1.0.1"
+
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz#938370a57b4a51dea2c77c15d5c5fdf895164009"
@@ -3847,6 +3919,16 @@ concat-stream@1.6.0, concat-stream@^1.5.0, concat-stream@^1.5.2, concat-stream@^
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+concat-stream@^1.4.7:
+  version "1.6.2"
+  resolved "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
+  integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+  dependencies:
+    buffer-from "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^2.2.2"
+    typedarray "^0.0.6"
+
 concurrently@^3.5.0:
   version "3.5.0"
   resolved "https://registry.npmjs.org/concurrently/-/concurrently-3.5.0.tgz#8cf1b7707a6916a78a4ff5b77bb04dec54b379b2"
@@ -3872,6 +3954,11 @@ concurrently@^3.5.1:
     spawn-command "^0.0.2-1"
     supports-color "^3.2.3"
     tree-kill "^1.1.0"
+
+condense-whitespace@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/condense-whitespace/-/condense-whitespace-1.0.0.tgz#8376d98ef028e6cb2cd2468e28ce42c5c65ab1a9"
+  integrity sha1-g3bZjvAo5sss0kaOKM5CxcZasak=
 
 config-chain@^1.1.11:
   version "1.1.12"
@@ -4566,6 +4653,13 @@ default-require-extensions@^1.0.0:
   dependencies:
     strip-bom "^2.0.0"
 
+default-user-agent@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/default-user-agent/-/default-user-agent-1.0.0.tgz#16c46efdcaba3edc45f24f2bd4868b01b7c2adc6"
+  integrity sha1-FsRu/cq6PtxF8k8r1IaLAbfCrcY=
+  dependencies:
+    os-name "~1.0.3"
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
@@ -4701,6 +4795,11 @@ dev-loader@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/dev-loader/-/dev-loader-0.1.0.tgz#4942f497ed39af6e9cf982f904c0bacc70f2a216"
 
+dev-null@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/dev-null/-/dev-null-0.1.1.tgz#5a205ce3c2b2ef77b6238d6ba179eb74c6a0e818"
+  integrity sha1-WiBc48Ky73e2I41roXnrdMag6Bg=
+
 dezalgo@^1.0.0:
   version "1.0.3"
   resolved "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
@@ -4809,7 +4908,7 @@ duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
-duplexer@^0.1.1:
+duplexer@^0.1.1, duplexer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
 
@@ -4919,6 +5018,11 @@ envinfo@^4.4.2:
   version "4.4.2"
   resolved "https://registry.npmjs.org/envinfo/-/envinfo-4.4.2.tgz#472c49f3a8b9bca73962641ce7cb692bf623cd1c"
 
+eol@~0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/eol/-/eol-0.2.0.tgz#2f6db086a243a46e3e5dbd0e13435c7ebebf09dd"
+  integrity sha1-L22whqJDpG4+Xb0OE0Ncfr6/Cd0=
+
 err-code@^1.0.0:
   version "1.1.2"
   resolved "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
@@ -4930,7 +5034,7 @@ errno@^0.1.1, errno@^0.1.3:
   dependencies:
     prr "~0.0.0"
 
-errno@~0.1.7:
+errno@~0.1.4, errno@~0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz#4684d71779ad39af177e3f007996f7c67c852618"
   dependencies:
@@ -4955,6 +5059,11 @@ errorhandler@^1.5.0:
   dependencies:
     accepts "~1.3.3"
     escape-html "~1.0.3"
+
+errors@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/errors/-/errors-0.2.0.tgz#0f51e889daa3e11b19e7186d11f104aa66eb2403"
+  integrity sha1-D1Hoidqj4RsZ5xhtEfEEqmbrJAM=
 
 es-abstract@^1.5.1, es-abstract@^1.6.1:
   version "1.10.0"
@@ -5565,6 +5674,11 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
+extend@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz#1b74985400171b85554894459c978de6ef453ab7"
+  integrity sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ==
+
 extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -5889,6 +6003,18 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
 
+form-data2@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/form-data2/-/form-data2-1.0.3.tgz#cba5e23601a6944d95ab7d7111ff9397a5cb2a4d"
+  integrity sha1-y6XiNgGmlE2Vq31xEf+Tl6XLKk0=
+  dependencies:
+    bluebird "^2.8.2"
+    combined-stream2 "^1.0.2"
+    debug "^2.1.1"
+    lodash "^2.4.1"
+    mime "^1.2.11"
+    uuid "^2.0.1"
+
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
@@ -5913,6 +6039,11 @@ form-data@~2.3.2:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
     mime-types "^2.1.12"
+
+form-fix-array@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/form-fix-array/-/form-fix-array-1.0.0.tgz#a1347a47e53117ab7bcdbf3e2f3ec91c66769bc8"
+  integrity sha1-oTR6R+UxF6t7zb8+Lz7JHGZ2m8g=
 
 format@^0.2.2:
   version "0.2.2"
@@ -6851,6 +6982,11 @@ http-cache-semantics@3.8.1, http-cache-semantics@^3.8.1:
   version "3.8.1"
   resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
 
+http-equiv-refresh@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/http-equiv-refresh/-/http-equiv-refresh-1.0.0.tgz#8ec538866042be5f3f7afa737d198d94beb1b07b"
+  integrity sha1-jsU4hmBCvl8/evpzfRmNlL6xsHs=
+
 http-errors@1.6.2, http-errors@~1.6.2:
   version "1.6.2"
   resolved "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
@@ -6902,6 +7038,11 @@ https-proxy-agent@^2.2.1:
   dependencies:
     agent-base "^4.1.0"
     debug "^3.1.0"
+
+humanize-duration@^3.9.1:
+  version "3.16.0"
+  resolved "https://registry.npmjs.org/humanize-duration/-/humanize-duration-3.16.0.tgz#c7ec3b898305f007c63893f891870b2b5a2e0a7d"
+  integrity sha512-LDnNSe8EkJjhRsijWgUK12UK7ivbCww2R3LW9quKdBDoQjeAewqnGHch5AJTCOny1cPLhnXTzvniXVP3B9O6Ew==
 
 humanize-ms@^1.2.1:
   version "1.2.1"
@@ -7262,6 +7403,11 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
+is-browser@^2.0.1:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz#fc084d59a5fced307d6708c59356bad7007371a9"
+  integrity sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ==
+
 is-buffer@^1.1.4:
   version "1.1.6"
   resolved "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
@@ -7578,6 +7724,11 @@ is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
+is-string@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz#cc3a9b69857d621e963725a24caeec873b826e64"
+  integrity sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=
+
 is-subset@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
@@ -7624,9 +7775,19 @@ is-word-character@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.1.tgz#5a03fa1ea91ace8a6eb0c7cd770eb86d65c8befb"
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+
+isbot@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/isbot/-/isbot-2.2.1.tgz#6c187c52122e5a2cd4d023b0215ffe6ade31c1b7"
+  integrity sha512-z0idtpC0uKKKTBhd1g73GREBWhCQdnJq8U5o+8XhgPvuPiRb/vkpNreLvtoneaZX9FNxDFOU0ohEj9hTWm/tPw==
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -8914,6 +9075,19 @@ libnpmaccess@^3.0.0:
     npm-package-arg "^6.1.0"
     npm-registry-fetch "^3.8.0"
 
+limited-request-queue@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/limited-request-queue/-/limited-request-queue-2.0.0.tgz#14c7c120b138060b19a2a1030abaf6693572650d"
+  integrity sha1-FMfBILE4BgsZoqEDCrr2aTVyZQ0=
+  dependencies:
+    is-browser "^2.0.1"
+    parse-domain "~0.2.0"
+
+link-types@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/link-types/-/link-types-1.1.0.tgz#af65e59db52e70c1ffb18ac4c3cb056bfe796830"
+  integrity sha1-r2XlnbUucMH/sYrEw8sFa/55aDA=
+
 lint-staged@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-4.2.3.tgz#5a1f12256af06110b96225f109dbf215009a37a9"
@@ -9165,6 +9339,11 @@ lodash.upperfirst@^4.2.0:
   version "4.17.5"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
+lodash@^2.4.1:
+  version "2.4.2"
+  resolved "http://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
+  integrity sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=
+
 lodash@^3.10.1:
   version "3.10.1"
   resolved "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -9250,17 +9429,17 @@ lowlight@^1.2.0:
   dependencies:
     highlight.js "~9.12.0"
 
-lru-cache@^4.0.1, lru-cache@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+lru-cache@4.1.x, lru-cache@^4.1.2, lru-cache@^4.1.3:
+  version "4.1.5"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lru-cache@^4.1.2, lru-cache@^4.1.3:
-  version "4.1.5"
-  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
-  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+lru-cache@^4.0.1, lru-cache@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
   dependencies:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
@@ -9347,6 +9526,11 @@ markdown-table@^1.1.0:
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
+
+maybe-callback@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/maybe-callback/-/maybe-callback-2.1.0.tgz#8afa0ba7b691a7ab123e7f12f65e32bb5d1f8243"
+  integrity sha1-ivoLp7aRp6sSPn8S9l4yu10fgkM=
 
 md5.js@^1.3.4:
   version "1.3.4"
@@ -9973,7 +10157,7 @@ nomnom@^1.8.1:
     chalk "~0.4.0"
     underscore "~1.6.0"
 
-"nopt@2 || 3":
+"nopt@2 || 3", nopt@^3.0.1:
   version "3.0.6"
   resolved "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
   integrity sha1-xkZdvwirzU2zWTF/eaxopkayj/k=
@@ -9986,6 +10170,20 @@ nopt@^4.0.1:
   dependencies:
     abbrev "1"
     osenv "^0.1.4"
+
+nopter@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/nopter/-/nopter-0.3.0.tgz#b9690e6fab8f256b37e4e7ccd23e2b38450cc71f"
+  integrity sha1-uWkOb6uPJWs35OfM0j4rOEUMxx8=
+  dependencies:
+    caller-path "~0.1.0"
+    camelcase "^1.0.2"
+    chalk "~0.5.1"
+    cli-table "~0.3.1"
+    eol "~0.2.0"
+    nopt "^3.0.1"
+    object-assign "^2.0.0"
+    splitargs "~0.0.3"
 
 normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.3.5, normalize-package-data@^2.4.0:
   version "2.4.0"
@@ -10154,6 +10352,11 @@ obj-props@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/obj-props/-/obj-props-1.1.0.tgz#626313faa442befd4a44e9a02c3cb6bde937b511"
 
+object-assign@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"
+  integrity sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=
+
 object-assign@^4, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -10290,6 +10493,14 @@ os-locale@^2.0.0:
     lcid "^1.0.0"
     mem "^1.1.0"
 
+os-name@~1.0.3:
+  version "1.0.3"
+  resolved "http://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz#1b379f64835af7c5a7f498b357cb95215c159edf"
+  integrity sha1-GzefZINa98Wn9JizV8uVIVwVnt8=
+  dependencies:
+    osx-release "^1.0.0"
+    win-release "^1.0.0"
+
 os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
@@ -10308,6 +10519,13 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+osx-release@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/osx-release/-/osx-release-1.1.0.tgz#f217911a28136949af1bf9308b241e2737d3cd6c"
+  integrity sha1-8heRGigTaUmvG/kwiyQeJzfTzWw=
+  dependencies:
+    minimist "^1.1.0"
 
 output-file-sync@^2.0.0:
   version "2.0.1"
@@ -10478,6 +10696,11 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
+parse-domain@~0.2.0:
+  version "0.2.2"
+  resolved "http://registry.npmjs.org/parse-domain/-/parse-domain-0.2.2.tgz#188989b1e2e7398bff3c4f4fd7dca157eb51fac1"
+  integrity sha1-GImJseLnOYv/PE9P19yhV+tR+sE=
+
 parse-entities@^1.0.2, parse-entities@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/parse-entities/-/parse-entities-1.1.1.tgz#8112d88471319f27abae4d64964b122fe4e1b890"
@@ -10543,6 +10766,13 @@ parse-passwd@^1.0.0:
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
+parse5@^3.0.2:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz#042f792ffdd36851551cf4e9e066b3874ab45b5c"
+  integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
+  dependencies:
+    "@types/node" "*"
 
 parse5@^5.0.0:
   version "5.1.0"
@@ -11249,7 +11479,7 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
-psl@^1.1.24:
+psl@^1.1.24, psl@^1.1.28:
   version "1.1.29"
   resolved "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
   integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
@@ -11298,6 +11528,11 @@ punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
 punycode@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz#5f863edc89b96db09074bad7947bf09056ca4e7d"
+
+punycode@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 puppeteer@^1.2.0:
   version "1.2.0"
@@ -11635,6 +11870,16 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
+
+readable-stream@~1.0.17:
+  version "1.0.34"
+  resolved "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readdir-scoped-modules@^1.0.0:
   version "1.0.2"
@@ -12389,6 +12634,29 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^2.0.0"
     inherits "^2.0.1"
 
+robot-directives@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.npmjs.org/robot-directives/-/robot-directives-0.3.0.tgz#174fb1ffc2a9b97877301e87c89b395f429d1f65"
+  integrity sha1-F0+x/8KpuXh3MB6HyJs5X0KdH2U=
+  dependencies:
+    isbot "^2.0.0"
+    useragent "^2.1.8"
+
+robots-txt-guard@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.npmjs.org/robots-txt-guard/-/robots-txt-guard-0.1.1.tgz#0dedec2dc325338989bb14158bef1f8539b705d4"
+  integrity sha512-6+nGkE6c2dI9/dmhmNcoMKVwJxlA6sgN/XNo0rm6LLdA0hnj4YkpgrZdhMPl58gJkAqeiHlf4+8tJcLM1tv1Ew==
+
+robots-txt-parse@~0.0.4:
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/robots-txt-parse/-/robots-txt-parse-0.0.4.tgz#f7d1f323f79921d7e9c6c4bbd25048f6e9810d71"
+  integrity sha1-99HzI/eZIdfpxsS70lBI9umBDXE=
+  dependencies:
+    bluebird "^2.3.5"
+    split "^0.3.0"
+    stream-combiner "^0.2.1"
+    through "^2.3.4"
+
 run-async@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-0.1.0.tgz#c8ad4a5e110661e402a7d21b530e009f25f8e389"
@@ -12527,7 +12795,7 @@ semver-diff@^2.0.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
-"semver@2.x || 3.x || 4 || 5", semver@^5.6.0:
+"semver@2.x || 3.x || 4 || 5", semver@^5.0.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -12971,11 +13239,23 @@ split@0.3.1:
   dependencies:
     through "2"
 
+split@^0.3.0:
+  version "0.3.3"
+  resolved "http://registry.npmjs.org/split/-/split-0.3.3.tgz#cd0eea5e63a211dfff7eb0f091c4133e2d0dd28f"
+  integrity sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=
+  dependencies:
+    through "2"
+
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
   dependencies:
     through "2"
+
+splitargs@~0.0.3:
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz#fe9f7ae657371b33b10cb80da143cf8249cf6b3b"
+  integrity sha1-/p965lc3GzOxDLgNoUPPgknPazs=
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -13055,6 +13335,14 @@ stream-browserify@^2.0.1:
     inherits "~2.0.1"
     readable-stream "^2.0.2"
 
+stream-combiner@^0.2.1:
+  version "0.2.2"
+  resolved "http://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz#aec8cbac177b56b6f4fa479ced8c1912cee52858"
+  integrity sha1-rsjLrBd7Vrb0+kec7YwZEs7lKFg=
+  dependencies:
+    duplexer "~0.1.1"
+    through "~2.3.4"
+
 stream-each@^1.1.0:
   version "1.2.2"
   resolved "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz#8e8c463f91da8991778765873fe4d960d8f616bd"
@@ -13071,6 +13359,13 @@ stream-http@^2.3.1:
     readable-stream "^2.2.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-length@^1.0.1, stream-length@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz#8277f3cbee49a4daabcfdb4e2f4a9b5e9f2c9f00"
+  integrity sha1-gnfzy+5JpNqrz9tOL0qbXp8snwA=
+  dependencies:
+    bluebird "^2.6.2"
 
 stream-shift@^1.0.0:
   version "1.0.0"
@@ -13124,7 +13419,12 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
-string_decoder@^0.10.25:
+string@^3.0.0:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/string/-/string-3.3.3.tgz#5ea211cd92d228e184294990a6cc97b366a77cb0"
+  integrity sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA=
+
+string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
@@ -13544,6 +13844,22 @@ throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
 
+through2-sink@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/through2-sink/-/through2-sink-1.0.0.tgz#5f106bba1d7330dad3cba5c0ab1863923256c399"
+  integrity sha1-XxBruh1zMNrTy6XAqxhjkjJWw5k=
+  dependencies:
+    through2 "~0.5.1"
+    xtend "~3.0.0"
+
+through2-spy@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/through2-spy/-/through2-spy-1.2.0.tgz#9c891ca9ca40e1e1e4cf31e1ac57f94cc9d248cb"
+  integrity sha1-nIkcqcpA4eHkzzHhrFf5TMnSSMs=
+  dependencies:
+    through2 "~0.5.1"
+    xtend "~3.0.0"
+
 through2@^2.0.0, through2@^2.0.1, through2@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
@@ -13551,7 +13867,15 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.2:
     readable-stream "^2.1.5"
     xtend "~4.0.1"
 
-through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3.6:
+through2@~0.5.1:
+  version "0.5.1"
+  resolved "http://registry.npmjs.org/through2/-/through2-0.5.1.tgz#dfdd012eb9c700e2323fd334f38ac622ab372da7"
+  integrity sha1-390BLrnHAOIyP9M084rGIqs3Lac=
+  dependencies:
+    readable-stream "~1.0.17"
+    xtend "~3.0.0"
+
+through@2, "through@>=2.2.7 <3", through@^2.3.4, through@^2.3.6, through@~2.3.4, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -13569,17 +13893,17 @@ tiny-emitter@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
 
+tmp@0.0.x, tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 tmp@^0.0.31:
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
   dependencies:
     os-tmpdir "~1.0.1"
-
-tmp@^0.0.33:
-  version "0.0.33"
-  resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  dependencies:
-    os-tmpdir "~1.0.2"
 
 tmpl@1.0.x:
   version "1.0.4"
@@ -13648,6 +13972,14 @@ tough-cookie@>=2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
     punycode "^1.4.1"
+
+tough-cookie@^2.3.1:
+  version "2.5.0"
+  resolved "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
+  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+  dependencies:
+    psl "^1.1.28"
+    punycode "^2.1.1"
 
 tough-cookie@^2.3.3:
   version "2.3.4"
@@ -14245,6 +14577,22 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+urlcache@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/urlcache/-/urlcache-0.7.0.tgz#3ff6a1e10b3d200aba132efc9f41dc1ad6d91b80"
+  integrity sha512-xOW4t6wJDT07+VunsHwePemyXXRidCSOZ/1RIILJi2XnB+81FA5H0MRvS63/7joTWjGLajcJJGvR5odpbkV6hw==
+  dependencies:
+    urlobj "0.0.11"
+
+urlobj@0.0.11:
+  version "0.0.11"
+  resolved "https://registry.npmjs.org/urlobj/-/urlobj-0.0.11.tgz#ddd3060876ae1cf0ff9e38a91d0574332b73794c"
+  integrity sha512-Ncck0WWtuFBbZhSYwKjK1AU2V51V98P/KHUPkaEc+mFy4xkpAHFNyVQT+S5SgtsJAr94e4wiKUucJSfasV2kBw==
+  dependencies:
+    is-object "^1.0.1"
+    is-string "^1.0.4"
+    object-assign "^4.1.1"
+
 use@^2.0.0:
   version "2.0.2"
   resolved "https://registry.npmjs.org/use/-/use-2.0.2.tgz#ae28a0d72f93bf22422a18a2e379993112dec8e8"
@@ -14258,6 +14606,14 @@ user-home@^2.0.0:
   resolved "https://registry.yarnpkg.com/user-home/-/user-home-2.0.0.tgz#9c70bfd8169bc1dcbf48604e0f04b8b49cde9e9f"
   dependencies:
     os-homedir "^1.0.0"
+
+useragent@^2.1.8:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
+  integrity sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==
+  dependencies:
+    lru-cache "4.1.x"
+    tmp "0.0.x"
 
 util-deprecate@~1.0.1:
   version "1.0.2"
@@ -14291,6 +14647,11 @@ utile@0.2.x:
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
+
+uuid@^2.0.1:
+  version "2.0.3"
+  resolved "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
+  integrity sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=
 
 uuid@^3.0.0, uuid@^3.0.1, uuid@^3.1.0:
   version "3.1.0"
@@ -14655,6 +15016,13 @@ widest-line@^1.0.0:
   dependencies:
     string-width "^1.0.1"
 
+win-release@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz#5fa55e02be7ca934edfc12665632e849b72e5209"
+  integrity sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=
+  dependencies:
+    semver "^5.0.1"
+
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -14850,6 +15218,11 @@ xregexp@4.0.0:
 xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.0, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+xtend@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz#5cce7407baf642cba7becda568111c493f59665a"
+  integrity sha1-XM50B7r2Qsunvs2laBEcST9ZZlo=
 
 y18n@^3.2.1:
   version "3.2.1"


### PR DESCRIPTION
Related #266 

* Enable `*.html` suffixing for all urls
* Allow relative links between `doc/` markdown files
* Keep backward compat with `./doc` prefixed links