### PR TITLE
fix: prefix route route correctly

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testMatch: ["<rootDir>/src/**/*.test.js"]
+};

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -97,6 +97,7 @@
     "globby": "^8.0.1",
     "hast-to-hyperscript": "^2.0.4",
     "highlight.js": "^9.6.0",
+    "jest": "^23.6.0",
     "lodash": "^4.15.0",
     "lowlight": "^1.2.0",
     "parse-json": "^4.0.0",

--- a/packages/client/src/app/containers/link.test.js
+++ b/packages/client/src/app/containers/link.test.js
@@ -1,0 +1,86 @@
+// @ts-check
+import { getHref } from "./link";
+
+test("external flag emits href as is", () => {
+  const expected = "/example";
+  const actual = getHref({ external: true, href: expected }, { location: "/" });
+
+  expect(actual).toBe(expected);
+});
+
+test("empty context location emits href as is", () => {
+  const expected = "/example";
+  const actual = getHref({ href: expected }, {});
+
+  expect(actual).toBe(expected);
+});
+
+test("honors legacy ./doc/ prefix", () => {
+  const actual = getHref(
+    { href: "./doc/example" },
+    { base: "/base/", location: "/" }
+  );
+  const expected = "/base/doc/example.html";
+
+  expect(actual).toBe(expected);
+});
+
+test("honors legacy ./pattern/ prefix", () => {
+  const actual = getHref(
+    { href: "./pattern/example" },
+    { base: "/base/", location: "/" }
+  );
+  const expected = "/base/pattern/example.html";
+
+  expect(actual).toBe(expected);
+});
+
+test("honors legacy ./doc/ prefix with base", () => {
+  const actual = getHref(
+    { href: "./base/doc/example" },
+    { base: "/base/", location: "/" }
+  );
+  const expected = "/base/doc/example.html";
+
+  expect(actual).toBe(expected);
+});
+
+test("honors legacy ./pattern/ prefix with base", () => {
+  const actual = getHref(
+    { href: "./base/pattern/example" },
+    { base: "/base/", location: "/" }
+  );
+  const expected = "/base/pattern/example.html";
+
+  expect(actual).toBe(expected);
+});
+
+// https://github.com/patternplate/patternplate/issues/295
+test("/ is prefixed with base", () => {
+  const actual = getHref({ href: "/" }, { base: "/base/", location: "/" });
+  const expected = "/base/";
+
+  expect(actual).toBe(expected);
+});
+
+test("calculates relative item => item url correctly", () => {
+  const expected = "doc/docs/some/doc.html";
+
+  const actual = getHref(
+    { href: "../some/doc" },
+    {
+      base: "/base/",
+      location: "/doc/docs/other/doc.html",
+      item: { path: "docs/other/docs.md" },
+      pool: [
+        {
+          contentType: "doc",
+          path: "docs/some/doc.md",
+          href: expected
+        }
+      ]
+    }
+  );
+
+  expect(actual).toBe(expected);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,14 +1247,6 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@patternplate/deploy-site@file:./packages/deploy":
-  version "3.1.1"
-  dependencies:
-    "@marionebl/sander" "^0.6.1"
-    execa "^0.9.0"
-    meow "^4.0.0"
-    surge "^0.20.1"
-
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"


### PR DESCRIPTION
* Add unit tests to mitigate future regressions
* Handle search case when prefixed
* Add case for `/`, e.g. on the logo when prefixed
* Closes #295 