### PR TITLE
fix(searchLabelBox): changed the order of the search labels

### DIFF
--- a/packages/client/src/app/selectors/found.js
+++ b/packages/client/src/app/selectors/found.js
@@ -22,24 +22,17 @@ const FIELDS = [
   }, */
   {
     type: "field",
-    key: "flag",
-    value: "flag",
-    description: "being flagged as [value]",
+    key: "version",
+    value: "version",
+    description: "having version of [value]",
     operators: ["=", "!=", ">", ">=", "<", "<=", "^=", "~="]
   },
   {
     type: "field",
-    key: "is",
-    value: "is",
-    description: "being of type [value]",
-    operators: ["=", "!="]
-  },
-  {
-    type: "field",
-    key: "has",
-    value: "has",
-    description: "having data of [value]",
-    operators: ["=", "!="]
+    key: "flag",
+    value: "flag",
+    description: "being flagged as [value]",
+    operators: ["=", "!=", ">", ">=", "<", "<=", "^=", "~="]
   },
   /* {
     type: "field",
@@ -57,18 +50,25 @@ const FIELDS = [
   },
   {
     type: "field",
-    key: "version",
-    value: "version",
-    description: "having version of [value]",
-    operators: ["=", "!=", ">", ">=", "<", "<=", "^=", "~="]
-  },
-  {
-    type: "field",
     key: "path",
     value: "path",
     description: "saved at [value] relative to patternplate.config.js",
     operators: ["=", "*="]
-  }
+  },
+  {
+    type: "field",
+    key: "is",
+    value: "is",
+    description: "being of type [value]",
+    operators: ["=", "!="]
+  },
+  {
+    type: "field",
+    key: "has",
+    value: "has",
+    description: "having data of [value]",
+    operators: ["=", "!="]
+  },
 ];
 
 const OPERATORS = [


### PR DESCRIPTION
Changed the order of the search labels, which makes more sense to me.
Used the order of an component, after that the path and than "is" and "has" which you can use for everything :)

new order:
- version
- flag
- tags
- path 
- is
- has