### PR TITLE
chore: add websocket client support metadata

### DIFF
--- a/packages/websocket-client/package.json
+++ b/packages/websocket-client/package.json
@@ -28,5 +28,9 @@
   "xo": false,
   "devDependencies": {
     "dependency-check": "^3.1.0"
+  },
+  "homepage": "https://github.com/patternplate/patternplate/tree/master/packages/websocket-client#readme",
+  "bugs": {
+    "url": "https://github.com/patternplate/patternplate/issues"
   }
 }


### PR DESCRIPTION
## Summary
- add npm `homepage` metadata for `@patternplate/websocket-client`
- add npm `bugs.url` metadata pointing to the public issue tracker

## Verification
- inspected `packages/websocket-client/package.json`
- metadata-only change; no runtime code, dependencies, or build behavior changed
